### PR TITLE
TK_7: Created organizations table

### DIFF
--- a/db/changelog/organizations/TK_7.xml
+++ b/db/changelog/organizations/TK_7.xml
@@ -19,14 +19,26 @@
                 <constraints nullable="false"/>
             </column>
             <column name="owner_id" type="UUID">
-                <constraints nullable="false" />
+                <constraints nullable="false"/>
             </column>
-            <column name="org_city" type="VARCHAR(100)"/>
-            <column name="org_state" type="VARCHAR(100)"/>
-            <column name="org_country" type="VARCHAR(100)" defaultValue="India"/>
-            <column name="org_postal_code" type="VARCHAR(20)"/>
-            <column name="org_address" type="TEXT"/>
-            <column name="org_description" type="TEXT"/>
+            <column name="org_city" type="VARCHAR(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="org_state" type="VARCHAR(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="org_country" type="VARCHAR(100)" defaultValue="India">
+                <constraints nullable="false"/>
+            </column>
+            <column name="org_postal_code" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="org_address" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="org_description" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
             <column name="created_at" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>

--- a/db/changelog/organizations/TK_7.xml
+++ b/db/changelog/organizations/TK_7.xml
@@ -18,7 +18,13 @@
             <column name="org_name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
+            <column name="org_desc" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
             <column name="owner_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="org_address" type="TEXT">
                 <constraints nullable="false"/>
             </column>
             <column name="org_city" type="VARCHAR(100)">
@@ -27,16 +33,10 @@
             <column name="org_state" type="VARCHAR(100)">
                 <constraints nullable="false"/>
             </column>
-            <column name="org_country" type="VARCHAR(100)" defaultValue="India">
-                <constraints nullable="false"/>
-            </column>
             <column name="org_postal_code" type="VARCHAR(20)">
                 <constraints nullable="false"/>
             </column>
-            <column name="org_address" type="TEXT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="org_description" type="TEXT">
+            <column name="org_country" type="VARCHAR(100)" defaultValue="India">
                 <constraints nullable="false"/>
             </column>
             <column name="created_at" type="TIMESTAMP">

--- a/db/changelog/organizations/TK_7.xml
+++ b/db/changelog/organizations/TK_7.xml
@@ -46,13 +46,13 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-                <addForeignKeyConstraint
-                        baseTableName="organizations"
-                        baseColumnNames="owner_id"
-                        constraintName="fk_owner_id"
-                        referencedTableName="members"
-                        referencedColumnNames="id"
-                        onDelete="CASCADE"/>
+        <addForeignKeyConstraint
+                baseTableName="organizations"
+                baseColumnNames="owner_id"
+                constraintName="fk_owner_id"
+                referencedTableName="members"
+                referencedColumnNames="member_id"
+                onDelete="CASCADE"/>
         <rollback>
             <dropTable tableName="organizations"/>
         </rollback>

--- a/db/changelog/organizations/TK_7.xml
+++ b/db/changelog/organizations/TK_7.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet id="TK_7_Create_Organizations_Table" author="Gurwinder Singh">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="organizations"/>
+            </not>
+        </preConditions>
+        <createTable tableName="organizations">
+            <column name="org_id" type="BIGSERIAL">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="org_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="owner_id" type="UUID">
+                <constraints nullable="false" />
+            </column>
+            <column name="org_city" type="VARCHAR(100)"/>
+            <column name="org_state" type="VARCHAR(100)"/>
+            <column name="org_country" type="VARCHAR(100)" defaultValue="India"/>
+            <column name="org_postal_code" type="VARCHAR(20)"/>
+            <column name="org_address" type="TEXT"/>
+            <column name="org_description" type="TEXT"/>
+            <column name="created_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <!--        <addForeignKeyConstraint-->
+        <!--                baseTableName="organizations"-->
+        <!--                baseColumnNames="owner_id"-->
+        <!--                constraintName="fk_owner_id"-->
+        <!--                referencedTableName="members"-->
+        <!--                referencedColumnNames="id"-->
+        <!--                onDelete="CASCADE"/>-->
+        <rollback>
+            <dropTable tableName="organizations"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/dbchangelog.xml
+++ b/dbchangelog.xml
@@ -6,7 +6,5 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
     <include file="db/changelog/user_management/TK_6.xml"/>
-    <include file="db/changelog/organizations/Tk_7.xml"/>
-
-
+    <include file="db/changelog/organizations/TK_7.xml"/>
 </databaseChangeLog>

--- a/dbchangelog.xml
+++ b/dbchangelog.xml
@@ -5,4 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
+    <include file="db/changelog/organizations/Tk_7.xml"/>
+
+
 </databaseChangeLog>


### PR DESCRIPTION
This Liquibase changeset creates a table called organizations to store basic details about organizations. It includes an org_id as a primary key to uniquely identify each record. The table stores important information like org_name and owner_id, which are required fields. It also has optional fields such as city, state, country (default is India), postal code, address, and description to give more details about the organization. Additionally, created_at and updated_at columns are used to track when the data is created and updated.